### PR TITLE
add tab navigation

### DIFF
--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -70,9 +70,9 @@ const Header = () => {
             >
               {pages.map((page) => (
                 <MenuItem key={page} onClick={handleCloseNavMenu}>
-                  <Typography textAlign="center" color="secondary">
+                  <Typography textAlign="center" color="secondary" variant="h6">
                     <Link
-                      style={{ textDecoration: "none", color:"black" }}
+                      style={{ textDecoration: "none", color: "black" }}
                       to={`/${page}`}
                     >
                       {page}
@@ -96,21 +96,25 @@ const Header = () => {
                 key={page}
                 onClick={handleCloseNavMenu}
                 sx={{ my: 2, color: "white", display: "block" }}
-                
               >
-                <Link
-                  style={{ textDecoration: "none", color: "white", variant:"outlined" }}
-                  to={`/${page}`}
-                >
-                  {page}
-                </Link>
+                {" "}
+                <Typography textAlign="center" color="secondary" variant="h6">
+                  <Link
+                    style={{
+                      textDecoration: "none",
+                      color: "white",
+                      variant: "outlined",
+                    }}
+                    to={`/${page}`}
+                  >
+                    {page}
+                  </Link>
+                </Typography>
               </Button>
             ))}
           </Box>
 
-          <Box sx={{ flexGrow: 0 }}>
-            Login
-          </Box>
+          <Box sx={{ flexGrow: 0 }}>Login</Box>
         </Toolbar>
       </Container>
     </AppBar>

--- a/src/components/Shared/editInfo.js
+++ b/src/components/Shared/editInfo.js
@@ -1,16 +1,23 @@
 import React from "react";
-import {TextField, Box} from "@mui/material";
+import {TextField, Box, Container, Typography} from "@mui/material";
 
 function EditInfo({title, id}) {
+
   return (
+    <Container>
+      <Typography variant="h6"
+      color="textSecondary"
+      component="h2"
+      gutterBottom>{`Optional: Update title and description for new ${title}`}</Typography>
     <Box
       component="form"
       autoComplete="off"
     >
       <TextField id="title" label="Title" variant="filled" defaultValue={title} fullWidth margin="normal" />
-      <TextField id="desc" label="Description" variant="standard" fullWidth margin="dense"/>
+      <TextField id="desc" label="Description" variant="filled" fullWidth margin="normal"/>
 
     </Box>
+    </Container>
   );
 }
 

--- a/src/components/Shared/editInfo.js
+++ b/src/components/Shared/editInfo.js
@@ -1,0 +1,17 @@
+import React from "react";
+import {TextField, Box} from "@mui/material";
+
+function EditInfo({title, id}) {
+  return (
+    <Box
+      component="form"
+      autoComplete="off"
+    >
+      <TextField id="title" label="Title" variant="filled" defaultValue={title} fullWidth margin="normal" />
+      <TextField id="desc" label="Description" variant="standard" fullWidth margin="dense"/>
+
+    </Box>
+  );
+}
+
+export default EditInfo;

--- a/src/components/Shared/tabNav.js
+++ b/src/components/Shared/tabNav.js
@@ -1,0 +1,71 @@
+import * as React from "react";
+import PropTypes from "prop-types";
+import Tabs from "@mui/material/Tabs";
+import Tab from "@mui/material/Tab";
+import Typography from "@mui/material/Typography";
+import Box from "@mui/material/Box";
+import { useParams } from "react-router-dom";
+import EditInfo from './editInfo'
+function TabPanel(props) {
+  const { children, value, index, ...other } = props;
+
+  return (
+    <div
+      role="tabpanel"
+      hidden={value !== index}
+      id={`editSurvey-${index}`}
+      aria-labelledby={`editSurvey-${index}`}
+      {...other}
+    >
+      {value === index && (
+        <Box sx={{ p: 3 }}>
+          <Typography>{children}</Typography>
+        </Box>
+      )}
+    </div>
+  );
+}
+
+TabPanel.propTypes = {
+  children: PropTypes.node,
+  index: PropTypes.number.isRequired,
+  value: PropTypes.number.isRequired,
+};
+
+function a11yProps(index) {
+  return {
+    id: `editSurvey-${index}`,
+    "aria-controls": `editSurvey-${index}`,
+  };
+}
+
+export default function TabNav({title}) {
+  const [value, setValue] = React.useState(0);
+
+  const handleChange = (event, newValue) => {
+    setValue(newValue);
+  };
+
+  let { id } = useParams();
+
+  return (
+    <Box sx={{ width: "100%", bgcolor: "background.paper" }}>
+      <Box sx={{ borderBottom: 1, borderColor: "divider" }}>
+        <Tabs value={value} onChange={handleChange} aria-label="edit survey">
+          <Tab label="Edit Info" {...a11yProps(0)} />
+          <Tab label="Design" {...a11yProps(1)} />
+          <Tab label="Preview" {...a11yProps(2)} />
+        </Tabs>
+      </Box>
+      <TabPanel value={value} index={0}>
+        <EditInfo id={id} title={title}></EditInfo>
+      </TabPanel>
+      <TabPanel value={value} index={1}>
+        Design view
+      </TabPanel>
+      <TabPanel value={value} index={2}>
+        Preview Updated Survey
+      </TabPanel>
+    </Box>
+  );
+}

--- a/src/components/Shared/tabNav.js
+++ b/src/components/Shared/tabNav.js
@@ -19,7 +19,7 @@ function TabPanel(props) {
     >
       {value === index && (
         <Box sx={{ p: 3 }}>
-          <Typography>{children}</Typography>
+          <Typography component="span">{children}</Typography>
         </Box>
       )}
     </div>

--- a/src/components/Templates/Template.js
+++ b/src/components/Templates/Template.js
@@ -1,6 +1,7 @@
 import React, {useState} from 'react'
 import {useLocation} from 'react-router-dom'
 import Container from "@mui/material/Container";
+import TabNav from '../Shared/tabNav';
 
 function TemplateDesign() {
   const l = useLocation();
@@ -10,7 +11,8 @@ function TemplateDesign() {
   
   return (
     <Container>
-      <h1>{title} Template</h1>
+      <h1>{title}</h1>
+      <TabNav title={title}></TabNav>
     </Container>
   )
 }

--- a/src/components/Templates/Template.js
+++ b/src/components/Templates/Template.js
@@ -2,7 +2,7 @@ import React, {useState} from 'react'
 import {useLocation} from 'react-router-dom'
 import Container from "@mui/material/Container";
 import TabNav from '../Shared/tabNav';
-
+import { Typography, Box } from '@mui/material';
 function TemplateDesign() {
   const l = useLocation();
   console.log(l.state)
@@ -11,8 +11,10 @@ function TemplateDesign() {
   
   return (
     <Container>
-      <h1>{title}</h1>
+      <Box sx={{bgcolor: "background.paper"}}>
+      <Typography variant="h2" mt={2} component="h2" >{title}</Typography>
       <TabNav title={title}></TabNav>
+      </Box>
     </Container>
   )
 }


### PR DESCRIPTION
closes #10 
Tab navigation passes title and id (with router's use params) when the user selects "use template."

To test: 
1. run app: npm start
2. select "templates" in top navigation bar
3. Click "use template" button (or preview then "use template" button)
4. Verify "Edit Info" tab contains template title and description text fields
5. Switch tabs and verify each tab has description matching the tab label.